### PR TITLE
Fix Error Message. Create bin file

### DIFF
--- a/bin/brakecheck
+++ b/bin/brakecheck
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require 'rspec'
+RSpec::Core::Runner.run([File.join(__FILE__, "..", "..", "lib", "bin_test.rb")])

--- a/brakecheck.gemspec
+++ b/brakecheck.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "bin"
+  spec.executables   = ['brakeman_check']
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.12"

--- a/lib/bin_test.rb
+++ b/lib/bin_test.rb
@@ -1,0 +1,10 @@
+require "brakecheck"
+RSpec.describe ENV['BRAKECHECK_GEM'] do
+  before do
+    WebMock.disable_net_connect!(allow: 'rubygems.org')
+  end
+
+  it 'is the lastest version' do
+    expect(ENV['BRAKECHECK_GEM']).to be_the_latest_version
+  end
+end

--- a/lib/bin_test.rb
+++ b/lib/bin_test.rb
@@ -1,7 +1,7 @@
 require "brakecheck"
 RSpec.describe ENV['BRAKECHECK_GEM'] do
   before do
-    WebMock.disable_net_connect!(allow: 'rubygems.org')
+    WebMock.disable_net_connect!(allow: 'rubygems.org') if defined? WebMock
   end
 
   it 'is the lastest version' do

--- a/lib/brakecheck.rb
+++ b/lib/brakecheck.rb
@@ -25,18 +25,14 @@ module Brakecheck
     RSpec::Matchers.define :be_the_latest_version do
       match do |gem_name|
         spec_from_file = loaded_specs(gem_name)
-        if spec_from_file == :not_in_bundle
-          return false
-        else
-          Brakecheck::Core.latest(gem_name) == loaded_specs(gem_name)
-        end
+        Brakecheck::Core.latest(gem_name) == spec_from_file
       end
 
-      failure_message do |actual|
-        if actual == :not_in_bundle
+      failure_message do |gem_name|
+        if loaded_specs(gem_name) == :not_in_bundle
           "that gem is not in the bundle"
         else
-          "expected gem to be #{expected} but was actually #{actual}."
+          "expected #{gem_name} to be #{Brakecheck::Core.latest(gem_name)} but was actually #{loaded_specs(gem_name)}."
         end
       end
 

--- a/spec/brakecheck_spec.rb
+++ b/spec/brakecheck_spec.rb
@@ -4,9 +4,8 @@ describe Brakecheck do
   include Brakecheck
 
   before do
-    expect(Bundler).to receive(:default_lockfile).and_return(File.join(Bundler.root, "spec", "test_gem.lock"))
-    stub_gem_request("footing", "1.0.2") # up to date
-    stub_gem_request("brakeman", "3.0.0") # outdated spec
+    expect(Bundler).to receive(:default_lockfile).at_least(1).times
+      .and_return(File.join(Bundler.root, "spec", "test_gem.lock"))
   end
 
   describe 'when the gem is current and in the bundle' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,4 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'brakecheck'
 require 'webmock/rspec'
 
-def stub_gem_request(name, version)
-  stub_request(:get, "https://rubygems.org/api/v1/versions/#{name}/latest.json").
-    to_return(status: 200, body: {"version": version}.to_json, headers: {'Content-Type' => 'application/json'})
-end
+WebMock.disable_net_connect!(allow: 'rubygems.org')

--- a/spec/test_gem.lock
+++ b/spec/test_gem.lock
@@ -6,7 +6,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    brakeman (3.4.1)
+    brakeman (3.4.0)
     footing (1.0.2)
     rake (10.5.0)
 


### PR DESCRIPTION
Now you can do

BRAKECHECK_GEM=somegem bundle exec brakecheck

(ie: use it with travis, also, we now auto-allow http requests to rubygems.org so no need to do webmock allow)